### PR TITLE
Replace slash with underscore in branch names

### DIFF
--- a/scripts/blitzallbranches.js
+++ b/scripts/blitzallbranches.js
@@ -31,7 +31,7 @@ VSS.require(["VSS/Controls", "VSS/Controls/Grids", "VSS/Controls/Dialogs",
 					$("#BranchCountSpan").html(count);
 					jQuery.each(branches, function (index, branch) {
 						if (branch.isBaseVersion) return;
-						var branchId = id+branch.name;
+						var branchId = id+branch.name.replace("/", "_");
 						$("#branchTableBody").append("<tr id=\"" + branchId + "\"></tr>");
 						var repoName;
 						gitClient.getRepository(id).then(function (repo) {


### PR DESCRIPTION
This patch replaces slashes with underscores when setting the `branchId`
variable. If `branchId` contains a forward slash, jQuery will throw an
exception later on, when `$("#"+ branchId +"")` is run and makes the plugin
unusable for projects where the convention is to prefix branches with
"feature/", "fix/", or "hotfix/".