### PR TITLE
Updating logic that parses git branches

### DIFF
--- a/scripts/blitzallbranches.js
+++ b/scripts/blitzallbranches.js
@@ -30,8 +30,8 @@ VSS.require(["VSS/Controls", "VSS/Controls/Grids", "VSS/Controls/Dialogs",
 					count += branches.length-1;
 					$("#BranchCountSpan").html(count);
 					jQuery.each(branches, function (index, branch) {
-						if (branch.name == "master") return;
-						var branchId = id+branch.name.replace("/", "_");
+						if (branch.name.indexOf("master") > -1) return;
+						var branchId = id+branch.name.replace(/[\.\/]/g, "_");
 						$("#branchTableBody").append("<tr id=\"" + branchId + "\"></tr>");
 						var repoName;
 						gitClient.getRepository(id).then(function (repo) {


### PR DESCRIPTION
This is a great little tool you've written - unfortunately we have a rather complex branch structure, so our branches have '.' characters in them and also more than one folder level, so multiple '/' characters and the existing logic was only removing the first '/' and not changing '.' at all so most of our branches didn't show up.
I've updated the logic that parses git branches to handle all occurrences of these characters branch names as they were trying to create dom elements with ids that were invalid, so never being created.