### PR TITLE
fix 400 and 404 

### DIFF
--- a/scripts/blitzallbranches.js
+++ b/scripts/blitzallbranches.js
@@ -26,6 +26,7 @@ VSS.require(["VSS/Controls", "VSS/Controls/Grids", "VSS/Controls/Dialogs",
 		gitClient.getRepositories(projCurr).then(function (repositories) {
 			jQuery.each(repositories, function (index, repository) {
 				var id = repository.id;
+				if (repository.isDisabled == true || repository.size == 0) return true; // -> repository is disabled  || repository has no branch/commit 
 				gitClient.getBranches(id,projCurr).then(function(branches){
 					count += branches.length-1;
 					$("#BranchCountSpan").html(count);


### PR DESCRIPTION
400 and 404 add loading all branches
~User gets unwanted  asked about to authenticate but even when provided nothing happens 

A repository may have no commits/branches ( when you create a repo without a README).
A repository can also be deactivated.

A similar problem was reported in another [add-on](https://github.com/cribeiro84/azure-devops-pull-request-hub/issues/180)